### PR TITLE
[skip ci] suppress "Bump Version and Publish to PyPI" on forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@ concurrency:
 on:
   push:
   pull_request:
+  schedule:
+    - cron: '0 0 * * 1'
 
 permissions:
   contents: read

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,8 +4,6 @@ on:
     push:
         branches:
             - main
-    schedule:
-        - cron: '0 0 * * 1'
 
 jobs:
     bump-version-and-publish:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,6 +15,9 @@ jobs:
         permissions:
             contents: write
 
+        # don't run on this job on forks
+        if: ${{ github.repository_owner == 'SwissFederalArchives' }}
+
         steps:
             - name: Checkout code
               uses: actions/checkout@v4


### PR DESCRIPTION
to avoid triggering of this job (and subsequent version bumps) on forks upon syncing their main branch